### PR TITLE
val.text evaluate single and multiple answer choices

### DIFF
--- a/commune/modules/vali/text/vali_text.py
+++ b/commune/modules/vali/text/vali_text.py
@@ -26,22 +26,34 @@ class ValiText(Vali):
         module.info(timeout=1)
         sample = self.sample()
         answers = c.copy(sample.pop('answers'))
+        
         prompt = f'COMPLETE THE JSON \n {sample} \n' + " GIVE THE ANSWER AS AN INDEX -> {answer_idx:int} ? \n ```json"
+      
         output = module.generate(prompt, max_tokens=256)
         if isinstance(output, str):
             output = '{' + output.split('{')[-1].split('}')[0] + '}'
             c.print(output)
             output = json.loads(output)
-        # if correct answer is in the choices
+        
+        # Handle different types of answer_idx values
         if 'answer_idx' not in output:
-            answer_idx = int(list(output.values())[0])
+            answer_idx = [int(list(output.values())[0])]
+        elif isinstance(output['answer_idx'], list):
+            answer_idx = [int(idx) for idx in output['answer_idx']]
         else:
-            answer_idx = int(output['answer_idx'])
-        if answer_idx in answers:
-            w = 1
-        else:
-            w = 0
-        return {'w': w, 'answer_idx': answer_idx, 'answers': answers, 'output': output, 'sample': sample}
+            answer_idx = [int(output['answer_idx'])]
+        
+        all_valid = all(idx in answers for idx in answer_idx)
+        w = 1 if all_valid else 0
+
+        # Return the result
+        return {
+            'w': w,
+            'answer_idx': answer_idx ,
+            'answers': answers,
+            'output': output,
+            'sample': sample
+            }
 
     def sample(self):
         # get sample
@@ -49,7 +61,7 @@ class ValiText(Vali):
         sample = {
             'question': sample['question'],
             'choices': c.shuffle(sample['incorrect_answers'] + sample['correct_answers']),
-            'answers': sample['correct_answers']
+            'answers': sample['correct_answers'] 
         }
 
         # shuffle choices 
@@ -57,6 +69,19 @@ class ValiText(Vali):
         sample['answers'] = [i for i, choice in sample['choices'].items() if choice in sample['answers']]
 
         return sample
+
+"""
+EXAMPLES: 
+# Modules decided to answer with a list:
+- 1. Result: {'w': 0, 'answer_idx': [1, 2], 'answers': [2, 3, 4]
+- 2. Result: {'w': 1, 'answer_idx': [1, 2], 'answers': [1, 2, 3, 4]
+
+# Module decided to answer only with one answer:
+- 3. Result: {'w': 1, 'answer_idx': [1], 'answers': [1, 2, 3, 4] 
+
+Note: In example 3, the module decided to answer only with: { "answer_idx": "1" }
+This is evaluated as the correct result. If the module wants to answer with a list, all answers have to be correct.
+"""
 
 
     


### PR DESCRIPTION
With the old implementation vali.text expects only this json format:
`{answer_idx:int}`
But multiple choices are actually correct, so this isn't very logical. You can update it, so that we can expect multiple answers,
all of these answers have to be correct though. This way the validator doesn't break on this json format :
`  "answer_idx": [
        "int",
        "int" 
    ] 
}`
Check out the examples