### PR TITLE
Non-destructive recipe as Makefile's default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ SUBTENSOR=0.0.0.0:9944
 
 PYTHON=python3
 
+build:
+	docker-compose build
+
 down:
 	docker-compose down
 stop:
@@ -20,9 +23,6 @@ restart:
 	make down && make up
 logs:
 	./$(COMMUNE).sh --commune
-
-build:
-	docker-compose build
 
 subspace:
 	make bash arg=$(SUBSPACE)


### PR DESCRIPTION
Changes Makefile so it have a non-destructive recipy as the first/default one.
Currently it's `make down` / `docker-compose build`.
