### PR TITLE
Gradio Version Control, Update ReadMe, Add requirements

### DIFF
--- a/commune/modules/model/image2video/model_image2video.py
+++ b/commune/modules/model/image2video/model_image2video.py
@@ -47,7 +47,7 @@ class ModelImage2video(c.Module):
         img = Image.open(img)
         wpercent = (basewidth / float(img.size[0]))
         hsize = int((float(img.size[1]) * float(wpercent)))
-        img = img.resize((basewidth, hsize), Image.ANTIALIAS)
+        img = img.resize((basewidth, hsize), Image.LANCZOS)
         return img
 
     def resize_img(self, img1, img2, output_name):
@@ -121,12 +121,12 @@ class ModelImage2video(c.Module):
                     with gr.Row():
                         # upload images and get image strings
                         input_arr = [
-                            gr.inputs.File(type="file", label="Images", file_count="multiple")
+                            gr.File(type="filepath", label="Images", file_count="multiple")
                         ]
 
                     with gr.Row():
-                        input_arr.append(gr.inputs.Slider(minimum=2, maximum=10, step=1, label="Times to Interpolate"))
-                        input_arr.append(gr.inputs.Slider(minimum=15, maximum=60, step=1, label="fps"))
+                        input_arr.append(gr.Slider(minimum=2, maximum=10, step=1, label="Times to Interpolate"))
+                        input_arr.append(gr.Slider(minimum=15, maximum=60, step=1, label="fps"))
                                 
                     # Rows of instructions & buttons
                     with gr.Row():
@@ -140,4 +140,4 @@ class ModelImage2video(c.Module):
             # Bind functions to buttons
             button_gen_video.click(fn=self.generate_interpolation, inputs=input_arr, outputs=output_interpolation)
 
-        demo.launch(quiet=True, enable_queue=True, share=True)
+        demo.launch(share=True)

--- a/commune/modules/model/image2video/readme.md
+++ b/commune/modules/model/image2video/readme.md
@@ -1,7 +1,14 @@
 # Convert Image to Video Module - README
 
+
 This module is designed for converting image to video. It offers a `gradio` function that users can convert the image.
 `gradio` function offers user-interface to users so that users can enjoy this module. Also I added docstring so that you can easily commit.
+
+#### install dependencies
+
+```
+pip install -r requirements.txt
+```
 
 #### Input:
 User upload several images using upload element
@@ -12,3 +19,7 @@ The video will out using that images
 ### Usage Example:
 
 ```c model.image2video gradio```
+
+### Fixing bugs
+In line 50 of model_image2video.py, replace Image.ANTIALIAS with Image.LANCZOS.
+In site-package/image_tools/sizes.py, replace ANTIALIAS with LANCZOS.

--- a/commune/modules/model/image2video/requirements.txt
+++ b/commune/modules/model/image2video/requirements.txt
@@ -1,0 +1,6 @@
+transformers
+tensorflow
+mediapy
+image_tools
+ffmpeg
+Pillow


### PR DESCRIPTION
- [x] Upgrade gradio version.
there has used  version 3.5 but many of the modules in this  repo are using the latest one-4.13
for example, gr.inputs was deprecated for latest version of gradio. replace the deprecated attributes with compatible ones.
- [x] Update ReadMe.
Add some notes to fix bug while running this modules.