### PR TITLE
warning fix due to conflicting SSL packages (see https://github.com/u…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ openai
 # scraping
 # beautifulsoup4
 # httplib2
-# urllib3
+urllib3<2
 # ray
 # ray[default]
 # ray[tune]


### PR DESCRIPTION
…rllib3/urllib3/issues/3020)

NOTE: run "pip uninstall commune && pip install -e ./" to re-install the packages and remove the error