### PR TITLE
fix cli DeprecationWarning

### DIFF
--- a/bin/c
+++ b/bin/c
@@ -1,6 +1,0 @@
-import warnings
-
-import commune as c
-
-if __name__ == "__main__":
-    c.cli()

--- a/commune/cli.py
+++ b/commune/cli.py
@@ -161,4 +161,6 @@ class cli(c.Module):
     def history_paths(cls, **kwargs):
         history = cls.history_module().history_paths(**kwargs) 
         return history
-    
+
+def main():
+    cli()

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 
 from setuptools import setup, find_packages
-from pkg_resources import parse_requirements
 from os import path
 from io import open
 here = path.abspath(path.dirname(__file__))
@@ -24,7 +23,11 @@ setup(
     author_email='',
     license='MIT',
     # install_requires=install_requires,
-    scripts=['bin/c'],
+    entry_points={
+        'console_scripts': [
+            'c=commune.cli:main',
+        ],
+    },
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',


### PR DESCRIPTION
All CLI usage currently has a Deprecation warning e.g.
```bash
$ c subnets
/home/ubuntu/.local/bin/c:4: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  __import__('pkg_resources').require('commune==0.0.1')
['Eden', 'architect', 'basi', 'biggie', 'commune', 'comsci', 'namespace', 'omega', 'oracle', 'router', 'smartnet', 'stonks', 'storage', 'subspace', 'synthia', 'text']
```

This PR edits the CLI packaging to get rid of the DeprecationWarning:
```bash
$ c subnets
['Eden', 'architect', 'basi', 'biggie', 'commune', 'comsci', 'namespace', 'omega', 'oracle', 'router', 'smartnet', 'stonks', 'storage', 'subspace', 'synthia', 'text']
```